### PR TITLE
check both start and end for `coords`

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -358,7 +358,7 @@ impl PathSegment {
     }
 
     pub fn coords(&self) -> Option<(usize, usize)> {
-        if self.start.is_some() {
+        if self.start.is_some() && self.end.is_some() {
             Some((self.start.unwrap(), self.end.unwrap()))
         } else {
             None


### PR DESCRIPTION
This fix avoids

```shell
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/graph.rs:362:49
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

and helped me in debugging https://github.com/pangenome/pggb/issues/299.