### PR TITLE
Add parameters to output split png files

### DIFF
--- a/scripts/panacus-visualize.py
+++ b/scripts/panacus-visualize.py
@@ -184,6 +184,8 @@ if __name__ == '__main__':
             help='Estimate growth parameters based on least-squares fit')
     parser.add_argument('-s', '--figsize', nargs=2, type=int, default=[10, 6],
             help='Set size of figure canvas')
+    parser.add_argument('--png', action='store_true',
+            help='Output figure as png')
 
     args = parser.parse_args()
 
@@ -234,7 +236,10 @@ if __name__ == '__main__':
 
     plt.tight_layout()
     with fdopen(stdout.fileno(), 'wb', closefd=False) as out:
-        plt.savefig(out, format='pdf')
+        if args.png:
+            plt.savefig(out, format='png')
+        else:
+            plt.savefig(out, format='pdf')
     plt.close()
 
 

--- a/scripts/panacus-visualize.py
+++ b/scripts/panacus-visualize.py
@@ -182,17 +182,13 @@ def full_extent(ax, pad=0.0):
     bbox = Bbox.union([item.get_window_extent() for item in items])
     return bbox.expanded(1.0 + pad, 1.0 + pad)
 
-def save_split_figures(ax, f):
+def save_split_figures(ax, f, format, prefix):
     for i, ax_row in enumerate(axs):
         for j, ax in enumerate(ax_row):
             extent = full_extent(ax).transformed(
                     f.dpi_scale_trans.inverted())
-            if args.png:
-                with open(f'out_{i}_{j}.png', 'wb+') as out:
-                    plt.savefig(out, bbox_inches=extent, format='png')
-            else:
-                with open(f'out_{i}_{j}.pdf', 'wb+') as out:
-                    plt.savefig(out, bbox_inches=extent, format='pdf')
+            with open(f'{prefix}{i}_{j}.{format}', 'wb+') as out:
+                plt.savefig(out, bbox_inches=extent, format=format)
 
 
 if __name__ == '__main__':
@@ -210,10 +206,12 @@ if __name__ == '__main__':
             help='Estimate growth parameters based on least-squares fit')
     parser.add_argument('-s', '--figsize', nargs=2, type=int, default=[10, 6],
             help='Set size of figure canvas')
-    parser.add_argument('--png', action='store_true',
-            help='Output figure as png')
+    parser.add_argument('-f', '--format', default='pdf', choices=['eps', 'jpeg', 'pdf', 'pgf', 'png', 'ps', 'raw', 'rgba', 'svg', 'tif', 'webp'],
+            help='Specify the format of the output (default: %(default)s)')
     parser.add_argument('--split_subfigures', action='store_true',
             help='Split output into multiple files')
+    parser.add_argument('--output_prefix', default="out_",
+            help="Prefix given to the files generated when splitting into subfigures")
 
     args = parser.parse_args()
 
@@ -265,12 +263,9 @@ if __name__ == '__main__':
     plt.tight_layout()
     if not args.split_subfigures:
         with fdopen(stdout.fileno(), 'wb', closefd=False) as out:
-            if args.png:
-                plt.savefig(out, format='png')
-            else:
-                plt.savefig(out, format='pdf')
+            plt.savefig(out, format=args.format)
     else:
-        save_split_figures(axs, f)
+        save_split_figures(axs, f, args.format, args.output_prefix)
 
     plt.close()
 

--- a/scripts/panacus-visualize.py
+++ b/scripts/panacus-visualize.py
@@ -24,6 +24,7 @@ import seaborn as sns
 
 PAT_PANACUS = re.compile('^#.+panacus (\S+) (.+)')
 N_HEADERS = 4
+SUPPORTED_FILE_FORMATS = plt.gcf().canvas.get_supported_filetypes().keys()
 
 ids = pd.IndexSlice
 
@@ -57,7 +58,7 @@ def clean_multicolumn_labels(df):
 
 def humanize_number(i, precision=0):
 
-    #assert i >= 0, f'non-negative number assumed, but received "{i}"'
+    #assert i >= 0, f'non-negative number assumed, but received '{i}''
 
     order = 0
     x = i
@@ -193,25 +194,26 @@ def save_split_figures(ax, f, format, prefix):
 
 if __name__ == '__main__':
     description='''
-    Visualize growth stats. PDF file will be plotted to stdout.
+    Visualize growth stats. Figures in given (output) format will be plotted to stdout, or optionally splitted into in individual files that start
+    with a given prefix.
     '''
     parser = ArgumentParser(formatter_class=ADHF, description=description)
     parser.add_argument('stats', type=open,
             help='Growth/Histogram table computed by panacus')
     parser.add_argument('-e', '--estimate_growth_params', action='store_true',
             help='Estimate growth parameters based on least-squares fit')
-    parser.add_argument('-l', '--legend_location', 
-            choices = ['lower left', 'lower right', 'upper left', 'upper right'], 
+    parser.add_argument('-l', '--legend_location',
+            choices = ['lower left', 'lower right', 'upper left', 'upper right'],
             default = 'upper left',
             help='Estimate growth parameters based on least-squares fit')
     parser.add_argument('-s', '--figsize', nargs=2, type=int, default=[10, 6],
             help='Set size of figure canvas')
-    parser.add_argument('-f', '--format', default='pdf', choices=['eps', 'jpeg', 'pdf', 'pgf', 'png', 'ps', 'raw', 'rgba', 'svg', 'tif', 'webp'],
-            help='Specify the format of the output (default: %(default)s)')
+    parser.add_argument('-f', '--format', default='pdf' in SUPPORTED_FILE_FORMATS and 'pdf' or SUPPORTED_FILE_FORMATS[0], choices=SUPPORTED_FILE_FORMATS,
+            help='Specify the format of the output')
     parser.add_argument('--split_subfigures', action='store_true',
             help='Split output into multiple files')
-    parser.add_argument('--output_prefix', default="out_",
-            help="Prefix given to the files generated when splitting into subfigures")
+    parser.add_argument('--output_prefix', default='out_',
+            help='Prefix given to the files generated when splitting into subfigures')
 
     args = parser.parse_args()
 

--- a/scripts/panacus-visualize.py
+++ b/scripts/panacus-visualize.py
@@ -172,11 +172,9 @@ def get_subplot_dim(df):
 
 def full_extent(ax, pad=0.0):
     '''
-    Get the full extent of an axes, including axes labels, tick labels, and
+    Gets the full extent of a given axes including labels, axis and
     titles.
     '''
-    # For text objects, we need to draw the figure first, otherwise the extents
-    # are undefined.
     ax.figure.canvas.draw()
     items = ax.get_xticklabels() + ax.get_yticklabels()
     items += [ax, ax.title, ax.xaxis.label, ax.yaxis.label]


### PR DESCRIPTION
Adds a parameter to output the result as png and another one to split each subfigure of the diagram into a different file. Implements #10