### PR TITLE
Reformat stats command output and add HTML for stats

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -741,7 +741,15 @@ pub fn run<W: Write>(params: Params, out: &mut BufWriter<W>) -> Result<(), Error
                         parse_gfa_paths_walks(&mut data, &abacus_aux, &graph_aux, &CountType::Node);
 
                     let stats = graph_aux.stats(&paths_len);
-                    write_histgrowth_html(&Some(hists), &growths, &hist_aux, &filename, None, Some(stats), out)?
+                    write_histgrowth_html(
+                        &Some(hists),
+                        &growths,
+                        &hist_aux,
+                        &filename,
+                        None,
+                        Some(stats),
+                        out,
+                    )?
                 }
             };
         }
@@ -801,12 +809,22 @@ pub fn run<W: Write>(params: Params, out: &mut BufWriter<W>) -> Result<(), Error
             log::info!("reporting histgrowth table");
             match output_format {
                 OutputFormat::Table => write_histgrowth_table(&hists, &growths, &hist_aux, out)?,
-                OutputFormat::Html => {
-                    write_histgrowth_html(&Some(hists), &growths, &hist_aux, &filename, None, None, out)?
-                }
+                OutputFormat::Html => write_histgrowth_html(
+                    &Some(hists),
+                    &growths,
+                    &hist_aux,
+                    &filename,
+                    None,
+                    None,
+                    out,
+                )?,
             };
         }
-        Params::Stats { ref gfa_file, output_format, .. } => {
+        Params::Stats {
+            ref gfa_file,
+            output_format,
+            ..
+        } => {
             let graph_aux = GraphAuxilliary::from_gfa(gfa_file, CountType::All);
 
             let abacus_aux = AbacusAuxilliary::from_params(&params, &graph_aux)?;
@@ -818,9 +836,7 @@ pub fn run<W: Write>(params: Params, out: &mut BufWriter<W>) -> Result<(), Error
             let filename = Path::new(&gfa_file).file_name().unwrap().to_str().unwrap();
             match output_format {
                 OutputFormat::Table => write_stats(stats, out)?,
-                OutputFormat::Html => {
-                    write_stats_html(&filename, stats, out)?
-                }
+                OutputFormat::Html => write_stats_html(&filename, stats, out)?,
             };
         }
         Params::Subset {
@@ -873,7 +889,14 @@ pub fn run<W: Write>(params: Params, out: &mut BufWriter<W>) -> Result<(), Error
                         parse_gfa_paths_walks(&mut data, &abacus_aux, &graph_aux, &CountType::Node);
 
                     let stats = graph_aux.stats(&paths_len);
-                    write_ordered_histgrowth_html(&abacus, &hist_aux, &gfa_file, count, Some(stats), out)?;
+                    write_ordered_histgrowth_html(
+                        &abacus,
+                        &hist_aux,
+                        &gfa_file,
+                        count,
+                        Some(stats),
+                        out,
+                    )?;
                 }
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -751,7 +751,10 @@ pub fn run<W: Write>(params: Params, out: &mut BufWriter<W>) -> Result<(), Error
             output_format,
             ..
         } => {
-            let graph_aux = GraphAuxilliary::from_gfa(gfa_file, count);
+            let graph_aux = match output_format {
+                OutputFormat::Html => GraphAuxilliary::from_gfa(gfa_file, CountType::All),
+                _ => GraphAuxilliary::from_gfa(gfa_file, count),
+            };
             let abacus_aux = AbacusAuxilliary::from_params(&params, &graph_aux)?;
             let abaci = AbacusByTotal::abaci_from_gfa(gfa_file, count, &graph_aux, &abacus_aux)?;
             let mut hists = Vec::new();
@@ -805,14 +808,12 @@ pub fn run<W: Write>(params: Params, out: &mut BufWriter<W>) -> Result<(), Error
         }
         Params::Stats { ref gfa_file, output_format, .. } => {
             let graph_aux = GraphAuxilliary::from_gfa(gfa_file, CountType::All);
-            //graph_aux.graph_info();
 
             let abacus_aux = AbacusAuxilliary::from_params(&params, &graph_aux)?;
             let mut data = bufreader_from_compressed_gfa(gfa_file);
             let (_, _, _, paths_len) =
                 parse_gfa_paths_walks(&mut data, &abacus_aux, &graph_aux, &CountType::Node);
 
-            //graph_aux.path_info(&paths_len);
             let stats = graph_aux.stats(&paths_len);
             let filename = Path::new(&gfa_file).file_name().unwrap().to_str().unwrap();
             match output_format {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -224,68 +224,95 @@ impl GraphAuxilliary {
         self.node_lens[v.0 as usize]
     }
 
-    pub fn graph_info(&self) {
+    pub fn stats(&self, paths_len: &Vec<u32>) -> Stats {
+        Stats {
+            graph_info: self.graph_info(),
+            path_info: self.path_info(paths_len)
+        }
+    }
+
+    pub fn graph_info(&self) -> GraphInfo {
         let degree = self.degree.as_ref().unwrap();
         let mut node_lens_sorted = self.node_lens[1..].to_vec();
         node_lens_sorted.sort_by(|a, b| b.cmp(a)); // decreasing, for N50
-        println!("Graph Info:");
-        println!("\tNumber of Nodes: {}", self.node_count);
-        println!("\tNumber of Edges: {}", self.edge_count);
-        println!(
-            "\tAverage Degree (undirected): {}",
-            averageu32(&degree[1..])
-        );
-        println!(
-            "\tMax Degree (undirected): {}",
-            degree[1..].iter().max().unwrap()
-        );
-        println!(
-            "\tMin Degree (undirected): {}",
-            degree[1..].iter().min().unwrap()
-        );
-        println!(
-            "\tNumber 0-degree Nodes: {}",
-            degree[1..].iter().filter(|&x| *x == 0).count()
-        );
-        println!(
-            "\tLargest Node (bp): {}",
-            node_lens_sorted.iter().max().unwrap()
-        );
-        println!(
-            "\tShortest Node (bp): {}",
-            node_lens_sorted.iter().min().unwrap()
-        );
-        println!(
-            "\tAverage Node Length (bp): {}",
-            averageu32(&node_lens_sorted)
-        );
-        println!(
-            "\tMedian Node Length (bp): {}",
-            median_already_sorted(&node_lens_sorted)
-        );
-        println!(
-            "\tN50 Node Length (bp): {}",
-            n50_already_sorted(&node_lens_sorted).unwrap()
-        );
+        // println!("Graph Info:");
+        // println!("\tNumber of Nodes: {}", self.node_count);
+        // println!("\tNumber of Edges: {}", self.edge_count);
+        // println!(
+        //     "\tAverage Degree (undirected): {}",
+        //     averageu32(&degree[1..])
+        // );
+        // println!(
+        //     "\tMax Degree (undirected): {}",
+        //     degree[1..].iter().max().unwrap()
+        // );
+        // println!(
+        //     "\tMin Degree (undirected): {}",
+        //     degree[1..].iter().min().unwrap()
+        // );
+        // println!(
+        //     "\tNumber 0-degree Nodes: {}",
+        //     degree[1..].iter().filter(|&x| *x == 0).count()
+        // );
+        // println!(
+        //     "\tLargest Node (bp): {}",
+        //     node_lens_sorted.iter().max().unwrap()
+        // );
+        // println!(
+        //     "\tShortest Node (bp): {}",
+        //     node_lens_sorted.iter().min().unwrap()
+        // );
+        // println!(
+        //     "\tAverage Node Length (bp): {}",
+        //     averageu32(&node_lens_sorted)
+        // );
+        // println!(
+        //     "\tMedian Node Length (bp): {}",
+        //     median_already_sorted(&node_lens_sorted)
+        // );
+        // println!(
+        //     "\tN50 Node Length (bp): {}",
+        //     n50_already_sorted(&node_lens_sorted).unwrap()
+        // );
+
+        GraphInfo {
+            node_count: self.node_count,
+            edge_count: self.edge_count,
+            average_degree: averageu32(&degree[1..]),
+            max_degree: *degree[1..].iter().max().unwrap(),
+            min_degree: *degree[1..].iter().min().unwrap(),
+            number_0_degree: degree[1..].iter().filter(|&x| *x == 0).count(),
+            largest_node: *node_lens_sorted.iter().max().unwrap(),
+            shortest_node: *node_lens_sorted.iter().min().unwrap(),
+            average_node: averageu32(&node_lens_sorted),
+            median_node: median_already_sorted(&node_lens_sorted),
+            n50_node: n50_already_sorted(&node_lens_sorted).unwrap(),
+        }
     }
 
-    pub fn path_info(&self, paths_len: &Vec<u32>) {
-        println!("Path/Walk Info:");
-        println!("\tNumber of Paths/Walks: {}", paths_len.len());
-        println!(
-            "\tLongest Path/Walk (node): {}",
-            paths_len.iter().max().unwrap()
-        );
-        println!(
-            "\tShortest Path/Walk (node): {}",
-            paths_len.iter().min().unwrap()
-        );
-        println!(
-            "\tAverage Number of Nodes in Paths/Walks: {}",
-            averageu32(&paths_len)
-        );
+    pub fn path_info(&self, paths_len: &Vec<u32>) -> PathInfo {
+        // println!("Path/Walk Info:");
+        // println!("\tNumber of Paths/Walks: {}", paths_len.len());
+        // println!(
+        //     "\tLongest Path/Walk (node): {}",
+        //     paths_len.iter().max().unwrap()
+        // );
+        // println!(
+        //     "\tShortest Path/Walk (node): {}",
+        //     paths_len.iter().min().unwrap()
+        // );
+        // println!(
+        //     "\tAverage Number of Nodes in Paths/Walks: {}",
+        //     averageu32(&paths_len)
+        // );
 
         //println!("\tDistribution of Strands in the Paths/Walks: TODO +/-");
+        PathInfo {
+            no_paths: paths_len.len(),
+            longest_path: *paths_len.iter().max().unwrap(),
+            shortest_path: *paths_len.iter().min().unwrap(),
+            average_path: averageu32(&paths_len),
+        }
     }
 
     pub fn number_of_items(&self, c: &CountType) -> usize {
@@ -644,5 +671,81 @@ impl fmt::Display for PathSegment {
             write!(formatter, "{}", self.id())?;
         }
         Ok(())
+    }
+}
+
+pub struct GraphInfo {
+    pub node_count: usize,
+    pub edge_count: usize,
+    pub average_degree: f32,
+    pub max_degree: u32,
+    pub min_degree: u32,
+    pub number_0_degree: usize,
+    pub largest_node: u32,
+    pub shortest_node: u32,
+    pub average_node: f32,
+    pub median_node: f64,
+    pub n50_node: u32,
+}
+
+pub struct PathInfo {
+    pub no_paths: usize,
+    pub longest_path: u32,
+    pub shortest_path: u32,
+    pub average_path: f32,
+}
+
+pub struct Stats {
+    pub graph_info: GraphInfo,
+    pub path_info: PathInfo,
+}
+
+impl fmt::Display for Stats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // let graph_info_text = "Graph Info".repeat(11);
+        // write!(f, "{}", graph_info_text)?;
+        // let path_info_text = "Path/Walk Info,".repeat(3) + "Path/Walk Info\n";
+        // write!(f, "{}", path_info_text)?;
+        // write!(f, "Number of Nodes,Number of Edges,Average Degree (undirected),Max Degree (undirected),Min Degree (undirected),
+        // Number 0-degree Nodes,Largest Node (bp),Shortest Node (bp),Average Node Length (bp),Median Node Length (bp),N50 Node Length (bp),")?;
+        // write!(f, "Number of Paths/Walks,Longest Path/Walk (node),Shortest Path/Walk (node),Average Number of Nodes in Paths/Walks\n")?;
+        // write!(
+        //     f,
+        //     "{},{},{},{},{},{},{},{},{},{},{},",
+        //     self.graph_info.node_count,
+        //     self.graph_info.edge_count,
+        //     self.graph_info.average_degree,
+        //     self.graph_info.max_degree,
+        //     self.graph_info.min_degree,
+        //     self.graph_info.number_0_degree,
+        //     self.graph_info.largest_node,
+        //     self.graph_info.shortest_node,
+        //     self.graph_info.average_node,
+        //     self.graph_info.median_node,
+        //     self.graph_info.n50_node
+        // )?;
+        // write!(
+        //     f,
+        //     "{},{},{},{}\n",
+        //     self.path_info.no_paths,
+        //     self.path_info.longest_path,
+        //     self.path_info.shortest_path,
+        //     self.path_info.average_path
+        // )
+        write!(f, "Graph Info\tNode Count\t{}\n", self.graph_info.node_count)?;
+        write!(f, "\tEdge Count\t{}\n", self.graph_info.edge_count)?;
+        write!(f, "\tPath Count\t{}\n", self.path_info.no_paths)?;
+        write!(f, "\t0-degree Node Count\t{}\n", self.graph_info.number_0_degree)?;
+        write!(f, "Node Info\tAverage Degree\t{}\n", self.graph_info.average_degree)?;
+        write!(f, "\tMax Degree\t{}\n", self.graph_info.max_degree)?;
+        write!(f, "\tMin Degree\t{}\n", self.graph_info.min_degree)?;
+        write!(f, "\tLargest\t{}\n", self.graph_info.largest_node)?;
+        write!(f, "\tShortest\t{}\n", self.graph_info.shortest_node)?;
+        write!(f, "\tAverage Length\t{}\n", self.graph_info.average_node)?;
+        write!(f, "\tMedian Length\t{}\n", self.graph_info.median_node)?;
+        write!(f, "\tN50 Node Length\t{}\n", self.graph_info.n50_node)?;
+        write!(f, "Path Info\tLongest\t{}\n", self.path_info.longest_path)?;
+        write!(f, "\tShortest\t{}\n", self.path_info.shortest_path)?;
+        write!(f, "\tAverage Node Count\t{}\n", self.path_info.average_path)
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -235,45 +235,6 @@ impl GraphAuxilliary {
         let degree = self.degree.as_ref().unwrap();
         let mut node_lens_sorted = self.node_lens[1..].to_vec();
         node_lens_sorted.sort_by(|a, b| b.cmp(a)); // decreasing, for N50
-        // println!("Graph Info:");
-        // println!("\tNumber of Nodes: {}", self.node_count);
-        // println!("\tNumber of Edges: {}", self.edge_count);
-        // println!(
-        //     "\tAverage Degree (undirected): {}",
-        //     averageu32(&degree[1..])
-        // );
-        // println!(
-        //     "\tMax Degree (undirected): {}",
-        //     degree[1..].iter().max().unwrap()
-        // );
-        // println!(
-        //     "\tMin Degree (undirected): {}",
-        //     degree[1..].iter().min().unwrap()
-        // );
-        // println!(
-        //     "\tNumber 0-degree Nodes: {}",
-        //     degree[1..].iter().filter(|&x| *x == 0).count()
-        // );
-        // println!(
-        //     "\tLargest Node (bp): {}",
-        //     node_lens_sorted.iter().max().unwrap()
-        // );
-        // println!(
-        //     "\tShortest Node (bp): {}",
-        //     node_lens_sorted.iter().min().unwrap()
-        // );
-        // println!(
-        //     "\tAverage Node Length (bp): {}",
-        //     averageu32(&node_lens_sorted)
-        // );
-        // println!(
-        //     "\tMedian Node Length (bp): {}",
-        //     median_already_sorted(&node_lens_sorted)
-        // );
-        // println!(
-        //     "\tN50 Node Length (bp): {}",
-        //     n50_already_sorted(&node_lens_sorted).unwrap()
-        // );
 
         GraphInfo {
             node_count: self.node_count,
@@ -291,21 +252,6 @@ impl GraphAuxilliary {
     }
 
     pub fn path_info(&self, paths_len: &Vec<u32>) -> PathInfo {
-        // println!("Path/Walk Info:");
-        // println!("\tNumber of Paths/Walks: {}", paths_len.len());
-        // println!(
-        //     "\tLongest Path/Walk (node): {}",
-        //     paths_len.iter().max().unwrap()
-        // );
-        // println!(
-        //     "\tShortest Path/Walk (node): {}",
-        //     paths_len.iter().min().unwrap()
-        // );
-        // println!(
-        //     "\tAverage Number of Nodes in Paths/Walks: {}",
-        //     averageu32(&paths_len)
-        // );
-
         //println!("\tDistribution of Strands in the Paths/Walks: TODO +/-");
         PathInfo {
             no_paths: paths_len.len(),
@@ -702,36 +648,6 @@ pub struct Stats {
 
 impl fmt::Display for Stats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // let graph_info_text = "Graph Info".repeat(11);
-        // write!(f, "{}", graph_info_text)?;
-        // let path_info_text = "Path/Walk Info,".repeat(3) + "Path/Walk Info\n";
-        // write!(f, "{}", path_info_text)?;
-        // write!(f, "Number of Nodes,Number of Edges,Average Degree (undirected),Max Degree (undirected),Min Degree (undirected),
-        // Number 0-degree Nodes,Largest Node (bp),Shortest Node (bp),Average Node Length (bp),Median Node Length (bp),N50 Node Length (bp),")?;
-        // write!(f, "Number of Paths/Walks,Longest Path/Walk (node),Shortest Path/Walk (node),Average Number of Nodes in Paths/Walks\n")?;
-        // write!(
-        //     f,
-        //     "{},{},{},{},{},{},{},{},{},{},{},",
-        //     self.graph_info.node_count,
-        //     self.graph_info.edge_count,
-        //     self.graph_info.average_degree,
-        //     self.graph_info.max_degree,
-        //     self.graph_info.min_degree,
-        //     self.graph_info.number_0_degree,
-        //     self.graph_info.largest_node,
-        //     self.graph_info.shortest_node,
-        //     self.graph_info.average_node,
-        //     self.graph_info.median_node,
-        //     self.graph_info.n50_node
-        // )?;
-        // write!(
-        //     f,
-        //     "{},{},{},{}\n",
-        //     self.path_info.no_paths,
-        //     self.path_info.longest_path,
-        //     self.path_info.shortest_path,
-        //     self.path_info.average_path
-        // )
         write!(f, "Graph Info\tNode Count\t{}\n", self.graph_info.node_count)?;
         write!(f, "\tEdge Count\t{}\n", self.graph_info.edge_count)?;
         write!(f, "\tPath Count\t{}\n", self.path_info.no_paths)?;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -227,7 +227,7 @@ impl GraphAuxilliary {
     pub fn stats(&self, paths_len: &Vec<u32>) -> Stats {
         Stats {
             graph_info: self.graph_info(),
-            path_info: self.path_info(paths_len)
+            path_info: self.path_info(paths_len),
         }
     }
 
@@ -648,11 +648,23 @@ pub struct Stats {
 
 impl fmt::Display for Stats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Graph Info\tNode Count\t{}\n", self.graph_info.node_count)?;
+        write!(
+            f,
+            "Graph Info\tNode Count\t{}\n",
+            self.graph_info.node_count
+        )?;
         write!(f, "\tEdge Count\t{}\n", self.graph_info.edge_count)?;
         write!(f, "\tPath Count\t{}\n", self.path_info.no_paths)?;
-        write!(f, "\t0-degree Node Count\t{}\n", self.graph_info.number_0_degree)?;
-        write!(f, "Node Info\tAverage Degree\t{}\n", self.graph_info.average_degree)?;
+        write!(
+            f,
+            "\t0-degree Node Count\t{}\n",
+            self.graph_info.number_0_degree
+        )?;
+        write!(
+            f,
+            "Node Info\tAverage Degree\t{}\n",
+            self.graph_info.average_degree
+        )?;
         write!(f, "\tMax Degree\t{}\n", self.graph_info.max_degree)?;
         write!(f, "\tMin Degree\t{}\n", self.graph_info.min_degree)?;
         write!(f, "\tLargest\t{}\n", self.graph_info.largest_node)?;

--- a/src/html.rs
+++ b/src/html.rs
@@ -223,7 +223,10 @@ pub fn generate_stats_tabs(stats: Stats) -> String {
         ("node_count", format!("{}", stats.graph_info.node_count)),
         ("edge_count", format!("{}", stats.graph_info.edge_count)),
         ("no_paths", format!("{}", stats.path_info.no_paths)),
-        ("number_0_degree", format!("{}", stats.graph_info.number_0_degree)),
+        (
+            "number_0_degree",
+            format!("{}", stats.graph_info.number_0_degree),
+        ),
         ("is_first", String::from("true")),
     ]);
     tab_content.push_str(&reg.render_template(&graph_info, &graph_vars).unwrap());
@@ -275,11 +278,17 @@ pub fn generate_stats_tabs(stats: Stats) -> String {
 </div>
 "##;
     let node_vars = HashMap::from([
-        ("average_degree", format!("{}", stats.graph_info.average_degree)),
+        (
+            "average_degree",
+            format!("{}", stats.graph_info.average_degree),
+        ),
         ("max_degree", format!("{}", stats.graph_info.max_degree)),
         ("min_degree", format!("{}", stats.graph_info.min_degree)),
         ("largest_node", format!("{}", stats.graph_info.largest_node)),
-        ("shortest_node", format!("{}", stats.graph_info.shortest_node)),
+        (
+            "shortest_node",
+            format!("{}", stats.graph_info.shortest_node),
+        ),
         ("average_node", format!("{}", stats.graph_info.average_node)),
         ("median_node", format!("{}", stats.graph_info.median_node)),
         ("n50_node", format!("{}", stats.graph_info.n50_node)),
@@ -313,7 +322,10 @@ pub fn generate_stats_tabs(stats: Stats) -> String {
 </div>
 "##;
     let path_vars = HashMap::from([
-        ("longest_path", format!("{}", stats.graph_info.average_degree)),
+        (
+            "longest_path",
+            format!("{}", stats.graph_info.average_degree),
+        ),
         ("shortest_path", format!("{}", stats.graph_info.max_degree)),
         ("average_path", format!("{}", stats.graph_info.min_degree)),
     ]);
@@ -396,8 +408,10 @@ pub fn write_hist_html<W: Write>(
         "content",
         reg.render_template(
             &content,
-            &HashMap::from([("hist_content", generate_hist_tabs(hists)),
-            ("stats_content", generate_stats_tabs(stats.unwrap()))]),
+            &HashMap::from([
+                ("hist_content", generate_hist_tabs(hists)),
+                ("stats_content", generate_stats_tabs(stats.unwrap())),
+            ]),
         )
         .unwrap(),
     );
@@ -484,7 +498,7 @@ pub fn write_histgrowth_html<W: Write>(
     }
     nav.push_str(&format!(r##"<button class="nav-link text-nowrap{}" id="v-pills-growth-tab" data-bs-toggle="pill" data-bs-target="#v-pills-growth" type="button" role="tab" aria-controls="v-pills-growth" aria-selected="true">{}pangenome growth</button>"##, if hists.is_some() { "" } else { " active"}, if ordered_names.is_some() { "ordered " } else {""} ));
     if stats.is_some() {
-         nav.push_str(r##"<button class="nav-link text-nowrap" id="v-pills-stats-tab" data-bs-toggle="pill" data-bs-target="#v-pills-stats" type="button" role="tab" aria-controls="v-pills-stats" aria-selected="false">pangenome stats</button>"##);
+        nav.push_str(r##"<button class="nav-link text-nowrap" id="v-pills-stats-tab" data-bs-toggle="pill" data-bs-target="#v-pills-stats" type="button" role="tab" aria-controls="v-pills-stats" aria-selected="false">pangenome stats</button>"##);
     }
 
     let mut js_objects = String::from("");

--- a/src/html.rs
+++ b/src/html.rs
@@ -190,11 +190,33 @@ pub fn generate_stats_tabs(stats: Stats) -> String {
     tab_navigation.push_str(r##"<button class="nav-link" id="nav-stats-3-tab" data-bs-toggle="tab" data-bs-target="#nav-stats-3" type="button" role="tab" aria-controls="nav-stats-3" aria-selected="false">Path Info</button>"##);
 
     let graph_info = r##"<div class="tab-pane fade{{#if is_first}} show active{{else}} d-none{{/if}}" id="nav-stats-1" role="tabpanel" aria-labelledby="nav-stats-1">
-    </br>
-    <p>Node count: {{{node_count}}}</p>
-    <p>Edge count: {{{edge_count}}}</p>
-    <p>Path count: {{{no_paths}}}</p>
-    <p>0-degree Node count: {{{number_0_degree}}}</p>
+        <br/>
+<table class="table table-striped table-hover">
+  <thead>
+    <tr>
+      <th scope="col">Measurement</th>
+      <th scope="col">Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Node count</td>
+      <td>{{{node_count}}}</td>
+    </tr>
+    <tr>
+      <td>Edge count</td>
+      <td>{{{edge_count}}}</td>
+    </tr>
+    <tr>
+      <td>Path count</td>
+      <td>{{{no_paths}}}</td>
+    </tr>
+    <tr>
+      <td>0-degree Node count</td>
+      <td>{{{number_0_degree}}}</td>
+    </tr>
+  </tbody>
+</table>
 </div>
 "##;
     let graph_vars = HashMap::from([
@@ -208,14 +230,48 @@ pub fn generate_stats_tabs(stats: Stats) -> String {
 
     let node_info = r##"<div class="tab-pane fade{{#if is_first}} show active{{else}} d-none{{/if}}" id="nav-stats-2" role="tabpanel" aria-labelledby="nav-stats-2">
     </br>
-    <p>Average Degree: {{{average_degree}}}</p>
-    <p>Maximum Degree: {{{max_degree}}}</p>
-    <p>Minimum Degree: {{{min_degree}}}</p>
-    <p>Largest Node (bp): {{{largest_node}}}</p>
-    <p>Shortest Node (bp): {{{shortest_node}}}</p>
-    <p>Average Node Length (bp): {{{average_node}}}</p>
-    <p>Median Node Length (bp): {{{median_node}}}</p>
-    <p>N50 Node Length (bp): {{{n50_node}}}</p>
+<table class="table table-striped table-hover">
+  <thead>
+    <tr>
+      <th scope="col">Measurement</th>
+      <th scope="col">Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Average Degree</td>
+      <td>{{{average_degree}}}</td>
+    </tr>
+    <tr>
+      <td>Maximum Degree</td>
+      <td>{{{max_degree}}}</td>
+    </tr>
+    <tr>
+      <td>Minimum Degree</td>
+      <td>{{{min_degree}}}</td>
+    </tr>
+    <tr>
+      <td>Largest Node (bp)</td>
+      <td>{{{largest_node}}}</td>
+    </tr>
+    <tr>
+      <td>Shortest Node (bp)</td>
+      <td>{{{shortest_node}}}</td>
+    </tr>
+    <tr>
+      <td>Average Node Length (bp)</td>
+      <td>{{{average_node}}}</td>
+    </tr>
+    <tr>
+      <td>Median Node Length (bp)</td>
+      <td>{{{median_node}}}</td>
+    </tr>
+    <tr>
+      <td>N50 Node Length (bp)</td>
+      <td>{{{n50_node}}}</td>
+    </tr>
+  </tbody>
+</table>
 </div>
 "##;
     let node_vars = HashMap::from([
@@ -232,9 +288,28 @@ pub fn generate_stats_tabs(stats: Stats) -> String {
 
     let path_info = r##"<div class="tab-pane fade{{#if is_first}} show active{{else}} d-none{{/if}}" id="nav-stats-3" role="tabpanel" aria-labelledby="nav-stats-3">
     </br>
-    <p>Longest Path (nodes): {{{longest_path}}}</p>
-    <p>Shortest Path (nodes): {{{shortest_path}}}</p>
-    <p>Average Node Count: {{{average_path}}}</p>
+<table class="table table-striped table-hover">
+  <thead>
+    <tr>
+      <th scope="col">Measurement</th>
+      <th scope="col">Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Longest Path (nodes)</td>
+      <td>{{{longest_path}}}</td>
+    </tr>
+    <tr>
+      <td>Shortest Path (nodes)</td>
+      <td>{{{shortest_path}}}</td>
+    </tr>
+    <tr>
+      <td>Average Node Count</td>
+      <td>{{{average_path}}}</td>
+    </tr>
+  </tbody>
+<table>
 </div>
 "##;
     let path_vars = HashMap::from([
@@ -284,10 +359,14 @@ pub fn write_hist_html<W: Write>(
 <div class="d-flex align-items-start">
 	<div class="nav flex-column nav-pills me-3" id="v-pills-tab" role="tablist" aria-orientation="vertical">
     	<button class="nav-link text-nowrap active" id="v-pills-hist-tab" data-bs-toggle="pill" data-bs-target="#v-pills-hist" type="button" role="tab" aria-controls="v-pills-hist" aria-selected="true">coverage histogram</button>
+        <button class="nav-link text-nowrap" id="v-pills-stats-tab" data-bs-toggle="pill" data-bs-target="#v-pills-stats" type="button" role="tab" aria-controls="v-pills-stats" aria-selected="false">pangenome stats</button>
  	</div>
   	<div class="tab-content w-100" id="v-pills-tabContent">
 		<div class="tab-pane fade show active" id="v-pills-hist" role="tabpanel" aria-labelledby="v-pills-hist-tab">
 {{{hist_content}}}
+		</div>
+		<div class="tab-pane fade" id="v-pills-stats" role="tabpanel" aria-labelledby="v-pills-stats-tab">
+{{{stats_content}}}
 		</div>
   </div>
 </div>
@@ -317,7 +396,8 @@ pub fn write_hist_html<W: Write>(
         "content",
         reg.render_template(
             &content,
-            &HashMap::from([("content", generate_hist_tabs(hists))]),
+            &HashMap::from([("hist_content", generate_hist_tabs(hists)),
+            ("stats_content", generate_stats_tabs(stats.unwrap()))]),
         )
         .unwrap(),
     );
@@ -362,7 +442,7 @@ pub fn write_histgrowth_html<W: Write>(
     }
     nav.push_str(&format!(r##"<button class="nav-link text-nowrap{}" id="v-pills-growth-tab" data-bs-toggle="pill" data-bs-target="#v-pills-growth" type="button" role="tab" aria-controls="v-pills-growth" aria-selected="true">{}pangenome growth</button>"##, if hists.is_some() { "" } else { " active"}, if ordered_names.is_some() { "ordered " } else {""} ));
     if stats.is_some() {
-         nav.push_str(&format!(r##"<button class="nav-link text-nowrap{}" id="v-pills-stats-tab" data-bs-toggle="pill" data-bs-target="#v-pills-stats" type="button" role="tab" aria-controls="v-pills-stats" aria-selected="false">{}pangenome stats</button>"##, if hists.is_some() { "" } else { " active"}, if ordered_names.is_some() { "ordered " } else {""} ));
+         nav.push_str(r##"<button class="nav-link text-nowrap" id="v-pills-stats-tab" data-bs-toggle="pill" data-bs-target="#v-pills-stats" type="button" role="tab" aria-controls="v-pills-stats" aria-selected="false">pangenome stats</button>"##);
     }
 
     let mut js_objects = String::from("");

--- a/src/html.rs
+++ b/src/html.rs
@@ -406,6 +406,48 @@ pub fn write_hist_html<W: Write>(
     write_html(&vars, out)
 }
 
+pub fn write_stats_html<W: Write>(
+    fname: &str,
+    stats: Stats,
+    out: &mut BufWriter<W>,
+) -> Result<(), std::io::Error> {
+    let mut vars: HashMap<&str, String> = HashMap::default();
+
+    let content = r##"
+<div class="d-flex align-items-start">
+	<div class="nav flex-column nav-pills me-3" id="v-pills-tab" role="tablist" aria-orientation="vertical">
+        <button class="nav-link text-nowrap active" id="v-pills-stats-tab" data-bs-toggle="pill" data-bs-target="#v-pills-stats" type="button" role="tab" aria-controls="v-pills-stats" aria-selected="true">pangenome stats</button>
+ 	</div>
+  	<div class="tab-content w-100" id="v-pills-tabContent">
+		<div class="tab-pane fade show active" id="v-pills-stats" role="tabpanel" aria-labelledby="v-pills-stats-tab">
+{{{stats_content}}}
+		</div>
+  </div>
+</div>
+"##;
+
+    let mut js_objects = String::from("const hists = [");
+    js_objects.push_str("];\n\nconst growths = [];\n");
+    js_objects.push_str("const fname = '");
+    js_objects.push_str(fname);
+    js_objects.push_str("';\n");
+
+    let reg = Handlebars::new();
+    vars.insert("fname", fname.to_string());
+    vars.insert("data_hook", js_objects);
+    vars.insert(
+        "content",
+        reg.render_template(
+            &content,
+            &HashMap::from([("stats_content", generate_stats_tabs(stats))]),
+        )
+        .unwrap(),
+    );
+
+    populate_constants(&mut vars);
+    write_html(&vars, out)
+}
+
 pub fn write_histgrowth_html<W: Write>(
     hists: &Option<Vec<Hist>>,
     growths: &Vec<(CountType, Vec<Vec<f64>>)>,

--- a/src/io.rs
+++ b/src/io.rs
@@ -1262,10 +1262,7 @@ pub fn write_histgrowth_table<W: Write>(
     write_table(&header_cols, &output_columns, out)
 }
 
-pub fn write_stats<W: Write>(
-    stats: Stats,
-    out: &mut BufWriter<W>,
-) -> Result<(), Error> {
+pub fn write_stats<W: Write>(stats: Stats, out: &mut BufWriter<W>) -> Result<(), Error> {
     log::info!("reporting graph stats table");
     writeln!(
         out,

--- a/src/io.rs
+++ b/src/io.rs
@@ -1262,6 +1262,19 @@ pub fn write_histgrowth_table<W: Write>(
     write_table(&header_cols, &output_columns, out)
 }
 
+pub fn write_stats<W: Write>(
+    stats: Stats,
+    out: &mut BufWriter<W>,
+) -> Result<(), Error> {
+    log::info!("reporting graph stats table");
+    writeln!(
+        out,
+        "# {}",
+        std::env::args().collect::<Vec<String>>().join(" ")
+    )?;
+    writeln!(out, "{}", stats)
+}
+
 pub fn write_ordered_histgrowth_table<W: Write>(
     abacus_group: &AbacusByGroup,
     hist_aux: &HistAuxilliary,
@@ -1318,6 +1331,7 @@ pub fn write_ordered_histgrowth_html<W: Write>(
     hist_aux: &HistAuxilliary,
     gfa_file: &str,
     count: CountType,
+    stats: Option<Stats>,
     out: &mut BufWriter<W>,
 ) -> Result<(), Error> {
     let mut growths: Vec<Vec<f64>> = hist_aux
@@ -1350,6 +1364,7 @@ pub fn write_ordered_histgrowth_html<W: Write>(
             .unwrap()
             .to_string(),
         Some(&abacus_group.groups),
+        stats,
         out,
     )?)
 }


### PR DESCRIPTION
Adds the option to output the stats command table as HTML. Other commands that also read a GFA file (`hist` and `histgrowth`) generate an additional tab displaying graph statistics. The plain text output was also reformatted so it can be stored in a TSV-file.