### PR TITLE
Replace GzDecoder with MultiGzDecoder in io.rs

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -7,7 +7,7 @@ use std::str::{self, FromStr};
 use std::sync::{Arc, Mutex};
 
 /* external use */
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 use itertools::Itertools;
 use quick_csv::Csv;
 use rayon::prelude::*;
@@ -32,7 +32,7 @@ pub fn bufreader_from_compressed_gfa(gfa_file: &str) -> BufReader<Box<dyn Read>>
     let f = std::fs::File::open(&gfa_file).expect("Error opening file");
     let reader: Box<dyn Read> = if gfa_file.ends_with(".gz") {
         log::info!("assuming that {} is gzip compressed..", &gfa_file);
-        Box::new(GzDecoder::new(f))
+        Box::new(MultiGzDecoder::new(f))
     } else {
         Box::new(f)
     };


### PR DESCRIPTION
A gzip member consists of a header, compressed data and a trailer. The gzip specification, however, allows multiple gzip members to be joined in a single stream. MultiGzDecoder will decode all consecutive members while GzDecoder will only decompress the first gzip member.

ref: https://github.com/wdecoster/chopper/commit/a4409fcda38ebffa32a87451da8139079c856b92#r142191434