### PR TITLE
Add warning when estimating growth for ordered growth plots

### DIFF
--- a/scripts/panacus-visualize.py
+++ b/scripts/panacus-visualize.py
@@ -252,12 +252,14 @@ if __name__ == '__main__':
                     axs_tc = axs[j, offset:offset+2]
                 plot_growth(df_tc, axs_tc, loc=args.legend_location, estimate_growth=args.estimate_growth_params)
             elif t == 'ordered-growth':
+                if args.estimate_growth_params:
+                    print(f'Cannot estimate growth using heaps law (-e parameter) when working with an ordered growth plot', file=stderr)
                 axs_tc = axs[j, -1:]
                 if non_cum_plots:
                     axs_tc = axs[j, -2:]
                 if df_tc.index[0] == '0' and df_tc.loc['0'].isna().all():
                     df_tc.drop(['0'], inplace=True)
-                plot_growth(df_tc, axs_tc, loc=args.legend_location, estimate_growth=args.estimate_growth_params)
+                plot_growth(df_tc, axs_tc, loc=args.legend_location, estimate_growth=False)
             else:
                 print(f'This script cannot visualize the content of type {t}, exiting.', file=stderr)
                 exit(1)

--- a/scripts/panacus-visualize.py
+++ b/scripts/panacus-visualize.py
@@ -254,6 +254,7 @@ if __name__ == '__main__':
             elif t == 'ordered-growth':
                 if args.estimate_growth_params:
                     print(f'Cannot estimate growth using heaps law (-e parameter) when working with an ordered growth plot', file=stderr)
+                    exit(1)
                 axs_tc = axs[j, -1:]
                 if non_cum_plots:
                     axs_tc = axs[j, -2:]


### PR DESCRIPTION
Add a warning when trying to estimate growth for ordered growth plots. Currently, it still generates the plots but just ignores the estimation of the growth.

Would it make more sense to just quit without generating plots?