### PR TITLE
Emit version + hash

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,10 @@
 use std::process::Command;
 fn main() {
     // note: add error checking yourself.
-    let output = Command::new("git").args(&["describe", "--tags"]).output().unwrap();
+    let output = Command::new("git")
+        .args(&["describe", "--tags"])
+        .output()
+        .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+use std::process::Command;
+fn main() {
+    // note: add error checking yourself.
+    let output = Command::new("git").args(&["describe", "--tags"]).output().unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -748,7 +748,7 @@ pub fn run<W: Write>(params: Params, out: &mut BufWriter<W>) -> Result<(), Error
                         let hists = Vec::new();
                         write_histgrowth_table(&hists, &growths, &hist_aux, out)?
                     }
-                },
+                }
                 OutputFormat::Html => {
                     if hist {
                         write_histgrowth_html(
@@ -762,16 +762,10 @@ pub fn run<W: Write>(params: Params, out: &mut BufWriter<W>) -> Result<(), Error
                         )?
                     } else {
                         write_histgrowth_html(
-                            &None,
-                            &growths,
-                            &hist_aux,
-                            filename,
-                            None,
-                            None,
-                            out,
+                            &None, &growths, &hist_aux, filename, None, None, out,
                         )?
                     }
-                },
+                }
             };
         }
         Params::Info {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -481,6 +481,7 @@ pub enum Params {
 }
 
 impl Params {
+    #[allow(dead_code)]
     pub fn test_default_histgrowth() -> Self {
         Params::Histgrowth {
             gfa_file: String::new(),

--- a/src/html.rs
+++ b/src/html.rs
@@ -58,7 +58,7 @@ pub fn populate_constants(vars: &mut HashMap<&str, String>) {
         "symbols_svg",
         String::from_utf8_lossy(SYMBOLS_SVG).into_owned(),
     );
-    vars.insert("version", env!("CARGO_PKG_VERSION").to_string());
+    vars.insert("version", option_env!("GIT_HASH").unwrap_or(env!("CARGO_PKG_VERSION")).to_string());
 
     let now = OffsetDateTime::now_utc();
     vars.insert(

--- a/src/html.rs
+++ b/src/html.rs
@@ -58,7 +58,12 @@ pub fn populate_constants(vars: &mut HashMap<&str, String>) {
         "symbols_svg",
         String::from_utf8_lossy(SYMBOLS_SVG).into_owned(),
     );
-    vars.insert("version", option_env!("GIT_HASH").unwrap_or(env!("CARGO_PKG_VERSION")).to_string());
+    vars.insert(
+        "version",
+        option_env!("GIT_HASH")
+            .unwrap_or(env!("CARGO_PKG_VERSION"))
+            .to_string(),
+    );
 
     let now = OffsetDateTime::now_utc();
     vars.insert(

--- a/src/io.rs
+++ b/src/io.rs
@@ -170,16 +170,12 @@ pub fn parse_tsv<R: Read>(
 
     let mut is_header = true;
     for (i, row) in reader.enumerate() {
-        let row = row
-            .map_err(|_| {
-                let msg = format!("unable to parse row {}", i);
-                log::error!("{}", &msg);
-                Error::new(ErrorKind::Other, msg)
-            })?;
-        let row: Vec<Vec<u8>> = row
-            .bytes_columns()
-            .map(|x| x.to_vec())
-            .collect();
+        let row = row.map_err(|_| {
+            let msg = format!("unable to parse row {}", i);
+            log::error!("{}", &msg);
+            Error::new(ErrorKind::Other, msg)
+        })?;
+        let row: Vec<Vec<u8>> = row.bytes_columns().map(|x| x.to_vec()).collect();
         if row.is_empty() {
             log::info!("Empty row, skipping");
             continue;
@@ -193,7 +189,11 @@ pub fn parse_tsv<R: Read>(
             }
             comments.push(c);
         // Skip empty lines (still need to have appropriate amount of tabs)
-        } else if row.iter().map(|x| x.is_empty()).fold(true, |acc, x| acc && x) {
+        } else if row
+            .iter()
+            .map(|x| x.is_empty())
+            .fold(true, |acc, x| acc && x)
+        {
             log::debug!("Skipping empty line");
             continue;
         // Handle comments

--- a/src/io.rs
+++ b/src/io.rs
@@ -1210,11 +1210,7 @@ pub fn write_ordered_table<W: Write>(
 
 pub fn write_hist_table<W: Write>(hists: &[Hist], out: &mut BufWriter<W>) -> Result<(), Error> {
     log::info!("reporting hist table");
-    writeln!(
-        out,
-        "# {}",
-        std::env::args().collect::<Vec<String>>().join(" ")
-    )?;
+    write_metadata_comments(out)?;
 
     let mut header_cols = vec![vec![
         "panacus".to_string(),
@@ -1241,11 +1237,7 @@ pub fn write_histgrowth_table<W: Write>(
     hist_aux: &HistAuxilliary,
     out: &mut BufWriter<W>,
 ) -> Result<(), Error> {
-    writeln!(
-        out,
-        "# {}",
-        std::env::args().collect::<Vec<String>>().join(" ")
-    )?;
+    write_metadata_comments(out)?;
 
     let mut header_cols = vec![vec![
         "panacus".to_string(),
@@ -1282,13 +1274,19 @@ pub fn write_histgrowth_table<W: Write>(
     write_table(&header_cols, &output_columns, out)
 }
 
-pub fn write_info<W: Write>(info: Info, out: &mut BufWriter<W>) -> Result<(), Error> {
-    log::info!("reporting graph info table");
+fn write_metadata_comments<W: Write>(out: &mut BufWriter<W>) -> Result<(), Error> {
     writeln!(
         out,
         "# {}",
         std::env::args().collect::<Vec<String>>().join(" ")
     )?;
+    let version = option_env!("GIT_HASH").unwrap_or(env!("CARGO_PKG_VERSION"));
+    writeln!(out, "# version {}", version)
+}
+
+pub fn write_info<W: Write>(info: Info, out: &mut BufWriter<W>) -> Result<(), Error> {
+    log::info!("reporting graph info table");
+    write_metadata_comments(out)?;
     writeln!(out, "{}", info)
 }
 
@@ -1298,11 +1296,7 @@ pub fn write_ordered_histgrowth_table<W: Write>(
     out: &mut BufWriter<W>,
 ) -> Result<(), Error> {
     log::info!("reporting ordered-growth table");
-    writeln!(
-        out,
-        "# {}",
-        std::env::args().collect::<Vec<String>>().join(" ")
-    )?;
+    write_metadata_comments(out)?;
 
     let mut output_columns: Vec<Vec<f64>> = hist_aux
         .coverage


### PR DESCRIPTION
Adds a line with the version + git commit hash to all table output. HTML output will also include both version and commit hash.

For the table this takes the form of:
```bash
# target/debug/panacus info test.gfa
# version 0.2.4-13-ge71f4c2
feature category        countable       value
...
```